### PR TITLE
chore: remove `deferred` in default vhost

### DIFF
--- a/dockerfiles/php-lol/nginx.conf
+++ b/dockerfiles/php-lol/nginx.conf
@@ -76,8 +76,8 @@ http {
   open_file_cache_errors on;
 
   server {
-    listen [::]:80 default_server deferred;
-    listen 80 default_server deferred;
+    listen [::]:80 default_server;
+    listen 80 default_server;
 
     # PHP fpm status
     location ~ ^/(status|ping)$ {

--- a/spec/php-lol_7.2_spec.rb
+++ b/spec/php-lol_7.2_spec.rb
@@ -100,7 +100,7 @@ describe 'Dockerfile' do
     it { should be_mode 444 }
     its(:sha256sum) {
       should eq \
-        'cb6dcc8b96f089a4a6689b529a808adef5133cd041f4a84b60eab9a470268d7d'
+        '563cdddbc20b910401b6d8c0505a03d3c3c886e0f5d3ca3054d5ca116daf476c'
     }
   end
 


### PR DESCRIPTION
instructs to use a deferred accept() (the TCP_DEFER_ACCEPT socket option) on Linux.