### PR TITLE
feat: thumbor

### DIFF
--- a/dockerfiles/thumbor/Dockerfile
+++ b/dockerfiles/thumbor/Dockerfile
@@ -1,0 +1,67 @@
+# Build
+FROM python:2.7.16-slim-stretch as build
+
+ENV \
+  DEBIAN_FRONTEND=noninteractive \
+  PATH=$PATH:/app/bin/ \
+  PYTHONUSERBASE=/app \
+  THUMBOR_VERSION=6.7.0
+
+RUN set -x \
+  && mkdir "$PYTHONUSERBASE" /etc/thumbor \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential=12.3 \
+    ca-certificates=20161130+nmu1+deb9u1 \
+    ffmpeg=7:3.2.14-1~deb9u1 \
+    graphicsmagick=1.3.30+hg15796-1~deb9u2 \
+    libboost-python-dev=1.62.0.1 \
+    libcurl4-openssl-dev=7.52.1-5+deb9u9 \
+    libgraphicsmagick++1-dev=1.3.30+hg15796-1~deb9u2 \
+    libjpeg-dev=1:1.5.1-2 \
+    libopencv-dev=2.4.9.1+dfsg1-2 \
+    libpng-dev=1.6.28-1+deb9u1 \
+    libssl-dev=1.1.0j-1~deb9u1 \
+    libtiff5-dev=4.0.8-2+deb9u4 \
+    webp=0.5.2-1 \
+  && pip install \
+    --no-cache-dir \
+    --install-option="--prefix=${PYTHONUSERBASE}" \
+      graphicsmagick-engine==0.1.1 \
+      opencv-engine==1.0.1 \
+      remotecv==2.2.2 \
+      thumbor-plugins==0.2.2 \
+      thumbor=="${THUMBOR_VERSION}" \
+  && thumbor-config > /etc/thumbor/thumbor.conf \
+  && chown nobody.nogroup /etc/thumbor/thumbor.conf \
+  && chmod 0444 /etc/thumbor/thumbor.conf \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Run
+FROM python:2.7.16-slim-stretch
+
+ENV \
+  DEBIAN_FRONTEND=noninteractive \
+  PYTHONUSERBASE=/app \
+  PATH=$PATH:/app/bin/
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates=20161130+nmu1+deb9u1 \
+    ffmpeg=7:3.2.14-1~deb9u1 \
+    graphicsmagick=1.3.30+hg15796-1~deb9u2 \
+    libjpeg-turbo-progs=1:1.5.1-2 \
+    webp=0.5.2-1 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build "$PYTHONUSERBASE" "$PYTHONUSERBASE"
+COPY --from=build /etc/thumbor/thumbor.conf /etc/thumbor/thumbor.conf
+
+USER nobody
+
+EXPOSE 8888/tcp
+
+ENTRYPOINT ["thumbor"]

--- a/spec/php-lol_7.2_spec.rb
+++ b/spec/php-lol_7.2_spec.rb
@@ -40,7 +40,7 @@ describe 'Dockerfile' do
     it { should be_mode 755 }
     its(:sha256sum) {
       should eq \
-        'e565db9e28cd79cea6f07c331967d017c83f0b61cf64bc10c994faedb83e5909'
+        'd596cd798b246ffa1038227e87aef1e460ea2d9b6f57c318f2c02cf6c7913b21'
     }
   end
 
@@ -50,7 +50,7 @@ describe 'Dockerfile' do
     it { should be_mode 755 }
     its(:sha256sum) {
       should eq \
-        '6647ac8fa3e9a9c2024bbf351e1b02eb7ec274cba59ab124e3a64fa0b95e2d91'
+        '236bdc6bc07aa132c5f78dc2d3ef75d36357f7a56a571572b24e871507e9a90c'
     }
   end
 

--- a/spec/thumbor_spec.rb
+++ b/spec/thumbor_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Dockerfile' do
+  dockerfile_dir = File.basename(__FILE__)[/(.*)_spec.rb/, 1]
+  image = Docker::Image.build_from_dir("#{DOCKERFILES}/#{dockerfile_dir}/")
+
+  set :os, family: :debian
+  set :backend, :docker
+  set :docker_image, image.id
+
+  %w[
+    ca-certificates
+    ffmpeg
+    graphicsmagick
+    libjpeg-turbo-progs
+    webp
+  ].each do |p|
+    describe package(p) do
+      it { should be_installed }
+    end
+  end
+
+  describe file('/app/bin/thumbor') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_mode 755 }
+    its(:sha256sum) {
+      should eq \
+        '53bb230c8cd682b9a9e528c482cf28b1385da09ccc1ef31453771671965d8dc8'
+    }
+  end
+
+  describe file('/usr/bin/jpegtran') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_mode 755 }
+    its(:sha256sum) {
+      should eq \
+        '407329018ec7e02dbc3d323ba652fffc986f5776245456cc91e9fa3d28434db5'
+    }
+  end
+end


### PR DESCRIPTION
`cat thumbor.conf`

```
ALLOW_UNSAFE_URL = True
RESULT_STORAGE = 'thumbor.result_storages.file_storage'
RESULT_STORAGE_EXPIRATION_SECONDS = 60
RESULT_STORAGE_FILE_STORAGE_ROOT_PATH = '/dev/shm'
RESULT_STORAGE_STORES_UNSAFE = True
SECURITY_KEY = 'changeme'
STORAGE = 'thumbor.storages.file_storage
```

```
docker run -p 8888:8888 -v $(pwd)/thumbor.conf:/etc/thumbor/thumbor.conf thumbor -l info -c /etc/thumbor/thumbor.conf
```